### PR TITLE
Change the makefile to use tabs instead of spaces to avoid errors.

### DIFF
--- a/makefile.linux
+++ b/makefile.linux
@@ -19,28 +19,28 @@ LIBPL_DEPS = $(addprefix $(BIN_DIR)/, clip.o gfx.o imode.o importer.o math.o pl.
 all: $(BIN_DIR) $(EXECS)
 
 $(BIN_DIR):
-    echo "[make] making bin directory"
-    mkdir -p $@
+	echo "[make] making bin directory"
+	mkdir -p $@
 
 $(LIBFW_DEPS): $(BIN_DIR)/%.o: fw/%.c fw/fw.h
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 $(LIBPL_DEPS): $(BIN_DIR)/%.o: %.c pl.h
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 $(LIBFW): $(LIBFW_DEPS)
-    ld -r -o $@ $(LIBFW_DEPS)
+	ld -r -o $@ $(LIBFW_DEPS)
 
 $(LIBPL): $(LIBPL_DEPS)
-    ld -r -o $@ $(LIBPL_DEPS)
+	ld -r -o $@ $(LIBPL_DEPS)
 
 $(EXECS): %: %.c pl.h fw/fw.h $(LIBPL) $(LIBFW)
-    $(CC) $(CFLAGS) $< -o $@ $(LIBPL) $(LIBFW) $(LIBS)
+	$(CC) $(CFLAGS) $< -o $@ $(LIBPL) $(LIBFW) $(LIBS)
 
 clean:
-    echo "[make] deleting bin directory"
-    rm -r $(BIN_DIR)
-    echo "[make] deleting executables"
-    for exec in $(EXECS) ; do \
-    rm $$exec ; \
-    done
+	echo "[make] deleting bin directory"
+	rm -r $(BIN_DIR)
+	echo "[make] deleting executables"
+	for exec in $(EXECS) ; do \
+	rm $$exec ; \
+	done


### PR DESCRIPTION
GNU Make requires the use of tabs instead of spaces for targets, otherwise it produces an error.