### PR TITLE
CMake: make installable for use from other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,15 @@ endif()
 
 project(PL3D-KC LANGUAGES C)
 
+include(GNUInstallDirs)
+
 if(UNIX)
   # apt install libx11-dev libxext-dev
   # brew install libx11 xquartz
   find_package(X11 REQUIRED)
 endif()
 
-add_library(fw OBJECT fw/pkb.c fw/sys.c
+add_library(fw fw/pkb.c fw/sys.c
 $<$<BOOL:${WIN32}>:fw/wvid.c>
 $<$<BOOL:${UNIX}>:fw/xvid.c>
 )
@@ -23,12 +25,28 @@ $<$<BOOL:${UNIX}>:X11::Xext>
 $<$<BOOL:${WIN32}>:winmm>
 )
 
-add_library(pl OBJECT clip.c gfx.c imode.c importer.c math.c pl.c)
+add_library(pl clip.c gfx.c imode.c importer.c math.c pl.c)
 target_include_directories(pl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(pl PRIVATE $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_WARNINGS>)
 
 add_executable(main main.c)
 target_link_libraries(main PRIVATE pl fw)
+
+# --- install
+# Rpath options necessary for shared library install to work correctly in user projects
+set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+
+# Necessary for shared library with Visual Studio / Windows oneAPI
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}" CACHE PATH "default install path" FORCE)
+endif()
+
+install(FILES fw/fw.h pl.h TYPE INCLUDE)
+install(TARGETS pl fw main)
 
 
 # --- auto-ignore build directory


### PR DESCRIPTION
specifically, for use from NTSC-CRT

QUESTION: do you want "fw.h" to be installed under `<prefix>/include/fw.h` or `<prefix>/include/fw/fw.h` ?