### PR TITLE
Fix potential segfault

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -110,7 +110,7 @@ PL_init(int *video, int hres, int vres)
 	}
 
 	/* set buffer offsets */
-	x_L = g3dresv + vres;
+    x_L = g3dresv;
     x_R = x_L + vres;
     xLc = x_R + vres;
     xRc = xLc + vres;

--- a/gfx.c
+++ b/gfx.c
@@ -201,7 +201,8 @@ pscan(int *stream, int dim, int len)
     scan_miny = INT_MAX;
     scan_maxy = INT_MIN;
     /* clean scan tables */
-    memcpy(x_L, xLc, 2 * PL_vres * sizeof(int));
+    memcpy(x_L, xLc, PL_vres * sizeof(int));
+    memcpy(x_R, xRc, PL_vres * sizeof(int));
   
     len = PL_clip_poly_x(VS, stream, dim, len);
     while (len--) {


### PR DESCRIPTION
fix buffer pointers assigning:
after PL_Init() _xRc_ was pointing to _attrbuf_ wich causes segfault when PL_MAX_SCREENSIZE was close-or-equal to window resolution